### PR TITLE
2022.10.25版暫定対応

### DIFF
--- a/SuperSimplePlus/Main.cs
+++ b/SuperSimplePlus/Main.cs
@@ -11,7 +11,7 @@ namespace SuperSimplePlus
     public class SSPPlugin : BasePlugin
     {
         public const String Id = "jp.satsumaimoamo.SuperSimplePlus";
-        public const String Version = "1.4.0";
+        public const String Version = "1.4.1";
 
         public const String ColoredModName = "<color=#8cfc03>SuperSimplePlus</color>";
 

--- a/SuperSimplePlus/Modules/ModTranslation.cs
+++ b/SuperSimplePlus/Modules/ModTranslation.cs
@@ -3,10 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using HarmonyLib;
 using Newtonsoft.Json.Linq;
-using SuperSimplePlus.Patches;
-using UnityEngine;
 
 namespace SuperSimplePlus
 {

--- a/SuperSimplePlus/Modules/ModTranslation.cs
+++ b/SuperSimplePlus/Modules/ModTranslation.cs
@@ -1,3 +1,4 @@
+using AmongUs.Data.Legacy;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -77,7 +78,7 @@ namespace SuperSimplePlus
             }
 
             var data = stringData[keyClean];
-            int lang = (int)SaveManager.LastLanguage;
+            int lang = (int)(SupportedLangs)LegacySaveManager.LastLanguage;
 
             if (data.ContainsKey(lang))
             {


### PR DESCRIPTION
# [変更点要約]
- 2022.10.25版暫定対応
    - 他Modのタイトルを吹っ飛ばす問題を修正
    - 設定ボタンが出ない問題を修正<br>

<br>

    -「(int)(SupportedLangs)LegacySaveManager.LastLanguage;」を用いている為近々修正する必要がある。